### PR TITLE
NETOBSERV-122: Health stats reporter

### DIFF
--- a/examples/goflow-kube.yaml
+++ b/examples/goflow-kube.yaml
@@ -47,6 +47,10 @@ spec:
   ports:
     - port: 2055
       protocol: UDP
+      name: flows
+    - port: 8080
+      protocol: TCP
+      name: health
   selector:
     app: goflow-kube
 ---

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/netobserv/loki-client-go v0.0.0-20211018150932-cb17208397a9
 	github.com/netsampler/goflow2 v1.0.5-0.20220106210010-20e8e567090c
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.31.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,68 @@
+// Package health provides the mechanism to report the health status of the service
+package health
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Status represents the different states that a service can have
+type Status int
+
+const (
+	// Starting the service. It is not yet ready to receive requests
+	Starting Status = iota
+	// Ready service. It is healthy and ready to receive requests
+	Ready
+	// Error status. The service is not healthy
+	Error
+)
+
+func (s Status) String() string {
+	switch s {
+	case Starting:
+		return "STARTING"
+	case Ready:
+		return "READY"
+	case Error:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Reporter of the health status and the statistics of the service
+type Reporter struct {
+	Status          Status
+	recordEnriched  prometheus.Counter
+	recordDiscarded *prometheus.CounterVec
+}
+
+func NewReporter(s Status) *Reporter {
+	return &Reporter{
+		Status: s,
+		recordEnriched: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "reader_record_enriched",
+				Help: "Number of records that have been successfully received and enriched.",
+			},
+			[]string{},
+		).WithLabelValues(),
+		recordDiscarded: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "reader_record_discarded",
+				Help: "Number of received received records that could not be enriched.",
+			},
+			[]string{"error"},
+		),
+	}
+}
+
+// RecordEnriched annotates a record as successfully processed
+func (r *Reporter) RecordEnriched() {
+	r.recordEnriched.Inc()
+}
+
+// RecordDiscarded annotates that a record couldn't be enriched due to the given error
+func (r *Reporter) RecordDiscarded(err error) {
+	r.recordDiscarded.WithLabelValues(err.Error()).Inc()
+}

--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -1,0 +1,135 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+
+	"github.com/netsampler/goflow2/utils"
+)
+
+const (
+	contentTypeHeader   = "Content-Type"
+	healthContentType   = "application/json"
+	statusCodeUnhealthy = http.StatusServiceUnavailable
+	statusCodeHealthy   = http.StatusOK
+	statusUp            = "UP"
+	statusDown          = "DOWN"
+	statusNameFlows     = "flows"
+	hostDataFieldName   = "host"
+	endpointHealth      = "/health"
+	endpointLive        = "/health/live"
+	endpointReady       = "/health/ready"
+	endpointMetrics     = "/metrics"
+)
+
+// HTTPReporter for health and metrics
+type HTTPReporter struct {
+	endpoints *http.ServeMux
+	reporter  *Reporter
+	registry  *prometheus.Registry
+}
+
+// Report is the representation of the information that will be presented to the
+// invoker of the health status. It follows the Microprofile Health 2.1 specification:
+// https://download.eclipse.org/microprofile/microprofile-health-2.1/microprofile-health-spec.html
+type Report struct {
+	Status string        `json:"status"`
+	Checks []StatusCheck `json:"checks"`
+}
+
+type StatusCheck struct {
+	Name   string      `json:"name"`
+	Status string      `json:"status"`
+	Data   interface{} `json:"data"`
+}
+
+func NewHTTPReporter(reporter *Reporter) HTTPReporter {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(reporter.recordEnriched)
+	reg.MustRegister(reporter.recordDiscarded)
+	reg.MustRegister(utils.NetFlowStats)
+	reg.MustRegister(utils.NetFlowErrors)
+	reg.MustRegister(utils.NetFlowSetRecordsStatsSum)
+	reg.MustRegister(utils.NetFlowTimeStatsSum)
+	reg.MustRegister(utils.NetFlowSetStatsSum)
+	reg.MustRegister(utils.NetFlowTemplatesStats)
+	hr := HTTPReporter{
+		reporter:  reporter,
+		endpoints: http.NewServeMux(),
+		registry:  reg,
+	}
+	hr.endpoints.HandleFunc(endpointHealth, hr.ready)
+	hr.endpoints.HandleFunc(endpointLive, hr.live)
+	hr.endpoints.HandleFunc(endpointReady, hr.ready)
+	hr.endpoints.HandleFunc(endpointMetrics, hr.metrics)
+	return hr
+}
+
+func (hs *HTTPReporter) Handler() http.Handler {
+	return hs.endpoints
+}
+
+func (hs *HTTPReporter) live(rw http.ResponseWriter, _ *http.Request) {
+	hs.writeStatus(rw, hs.reporter.Status != Error)
+}
+
+func (hs *HTTPReporter) ready(rw http.ResponseWriter, _ *http.Request) {
+	hs.writeStatus(rw, hs.reporter.Status == Ready)
+}
+
+func (hs *HTTPReporter) writeStatus(rw http.ResponseWriter, up bool) {
+	host, err := os.Hostname()
+	if err != nil {
+		host = err.Error()
+	}
+	checkMetrics := map[string]interface{}{
+		hostDataFieldName: host,
+	}
+	var statusName string
+	var statusCode int
+	if up {
+		statusName = statusUp
+		statusCode = statusCodeHealthy
+	} else {
+		statusName = statusDown
+		statusCode = statusCodeUnhealthy
+	}
+	report := Report{
+		Status: statusName,
+		Checks: []StatusCheck{{
+			Name:   statusNameFlows,
+			Status: statusName,
+			Data:   checkMetrics,
+		}},
+	}
+	rw.Header().Set(contentTypeHeader, healthContentType)
+	rw.WriteHeader(statusCode)
+	out, err := json.Marshal(report)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if _, err := rw.Write(out); err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (hs *HTTPReporter) metrics(rw http.ResponseWriter, _ *http.Request) {
+	mfs, err := hs.registry.Gather()
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		_, _ = rw.Write([]byte(err.Error()))
+		return
+	}
+	for _, mf := range mfs {
+		if _, err := expfmt.MetricFamilyToText(rw, mf); err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			_, _ = rw.Write([]byte(err.Error()))
+			return
+		}
+	}
+}

--- a/pkg/health/http_test.go
+++ b/pkg/health/http_test.go
@@ -1,0 +1,82 @@
+package health
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/netsampler/goflow2/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testCase struct {
+	status         Status
+	path           string
+	expectedCode   int
+	expectedStatus string
+}
+
+func TestHttpReporter_Health(t *testing.T) {
+	reporter := NewReporter(Starting)
+	svc := NewHTTPReporter(reporter)
+	server := httptest.NewServer(svc.Handler())
+	defer server.Close()
+
+	for _, tc := range []testCase{
+		{status: Starting, path: "/health", expectedCode: 503, expectedStatus: "DOWN"},
+		{status: Starting, path: "/health/ready", expectedCode: 503, expectedStatus: "DOWN"},
+		{status: Starting, path: "/health/live", expectedCode: 200, expectedStatus: "UP"},
+		{status: Ready, path: "/health", expectedCode: 200, expectedStatus: "UP"},
+		{status: Ready, path: "/health/ready", expectedCode: 200, expectedStatus: "UP"},
+		{status: Ready, path: "/health/live", expectedCode: 200, expectedStatus: "UP"},
+		{status: Error, path: "/health", expectedCode: 503, expectedStatus: "DOWN"},
+		{status: Error, path: "/health/ready", expectedCode: 503, expectedStatus: "DOWN"},
+		{status: Error, path: "/health/live", expectedCode: 503, expectedStatus: "DOWN"},
+	} {
+		t.Run(tc.status.String()+tc.path, func(t *testing.T) {
+			reporter.Status = tc.status
+			resp, err := server.Client().Get(server.URL + tc.path)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedCode, resp.StatusCode)
+			assert.Contains(t, resp.Header["Content-Type"], "application/json")
+			reported := Report{}
+			d := json.NewDecoder(resp.Body)
+			require.NoError(t, d.Decode(&reported))
+			assert.Equal(t, tc.expectedStatus, reported.Status)
+			require.Len(t, reported.Checks, 1)
+			assert.Equal(t, "flows", reported.Checks[0].Name)
+			assert.Equal(t, tc.expectedStatus, reported.Checks[0].Status)
+			require.IsType(t, map[string]interface{}{}, reported.Checks[0].Data)
+			assert.Contains(t, reported.Checks[0].Data.(map[string]interface{}), "host")
+		})
+	}
+}
+
+func TestHttpReporter_Metrics(t *testing.T) {
+	reporter := NewReporter(Ready)
+	svc := NewHTTPReporter(reporter)
+	svc.reporter.RecordEnriched()
+	svc.reporter.RecordDiscarded(errors.New("file not found"))
+	utils.NetFlowStats.WithLabelValues("foo", "9").Inc()
+	utils.NetFlowStats.WithLabelValues("foo", "9").Inc()
+	utils.NetFlowStats.WithLabelValues("bar", "9").Inc()
+	utils.NetFlowErrors.WithLabelValues("foo", "boom").Inc()
+	server := httptest.NewServer(svc.Handler())
+	defer server.Close()
+	resp, err := server.Client().Get(server.URL + "/metrics")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	body := string(bodyBytes)
+	assert.Contains(t, body, `flow_process_nf_count{router="foo",version="9"} 2`)
+	assert.Contains(t, body, `flow_process_nf_count{router="bar",version="9"} 1`)
+	assert.Contains(t, body, `flow_process_nf_errors_count{error="boom",router="foo"} 1`)
+	assert.Contains(t, body, "reader_record_enriched 1")
+	assert.Contains(t, body, `reader_record_discarded{error="file not found"} 1`)
+}

--- a/pkg/reader/reader_test.go
+++ b/pkg/reader/reader_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netobserv/goflow2-kube-enricher/pkg/health"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
@@ -42,6 +44,7 @@ func setupSimpleReader() (*Reader, *mock.InformersMock) {
 		log:       logrus.NewEntry(logrus.New()),
 		informers: informers,
 		config:    config.Default(),
+		health:    health.NewReporter(health.Starting),
 	}
 	return &r, informers
 }

--- a/test/integration/service.go
+++ b/test/integration/service.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/netobserv/goflow2-kube-enricher/pkg/health"
+
 	"github.com/golang/snappy"
 	"github.com/netobserv/loki-client-go/pkg/logproto"
 
@@ -90,7 +92,9 @@ func StartKubeEnricher(clientset kubernetes.Interface, clock func() time.Time) (
 			IPFields: map[string]string{
 				"SrcAddr": "",
 			},
-		}, clientset)
+		},
+		health.NewReporter(health.Starting),
+		clientset)
 	go r.Start(ctx, &loki)
 
 	conn, err := net.Dial("udp", fmt.Sprintf(":%d", listenPort))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,6 +97,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.11.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 # github.com/prometheus/client_model v0.2.0


### PR DESCRIPTION
Status report based on [Eclipse Microprofile 2.1](https://download.eclipse.org/microprofile/microprofile-health-2.1/microprofile-health-spec.html).


Implements `/health/ready` and `/health/live` endpoints, returning something like:

```json
{
    "checks": [
        {
            "data": {
                "host": "goflow-kube-54485b9d94-s695x"
            },
            "name": "flows",
            "status": "UP"
        }
    ],
    "status": "UP"
}
```

It also implements a `/metrics` endpoint to know the exact information about flows processed, templates received, etc...:

```
# HELP flow_process_nf_count NetFlows processed.
# TYPE flow_process_nf_count counter
flow_process_nf_count{router="100.64.0.2",version="10"} 229
flow_process_nf_count{router="100.64.0.3",version="10"} 22
flow_process_nf_count{router="100.64.0.4",version="10"} 39
flow_process_nf_count{router="100.64.0.5",version="10"} 103
# HELP flow_process_nf_delay_summary_seconds NetFlows time difference between time of flow and processing.
# TYPE flow_process_nf_delay_summary_seconds summary
flow_process_nf_delay_summary_seconds{router="100.64.0.2",version="10",quantile="0.5"} 59
flow_process_nf_delay_summary_seconds{router="100.64.0.2",version="10",quantile="0.9"} 60
flow_process_nf_delay_summary_seconds{router="100.64.0.2",version="10",quantile="0.99"} 1.8446744073709552e+19
flow_process_nf_delay_summary_seconds_sum{router="100.64.0.2",version="10"} 2.9514790517935283e+20
(....) etc
```