### PR TITLE
Decoupling processes and components

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -1,7 +1,10 @@
 // Package format defines a Format interface for various input formats
 package format
 
+import "context"
+
 type Format interface {
 	Next() (map[string]interface{}, error)
+	Start(ctx context.Context)
 	Shutdown()
 }

--- a/pkg/format/json/json.go
+++ b/pkg/format/json/json.go
@@ -3,6 +3,7 @@ package json
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 )
@@ -33,4 +34,8 @@ func (j *Format) Next() (map[string]interface{}, error) {
 
 func (j *Format) Shutdown() {
 	//Can't shutdown json formatter
+}
+
+func (j *Format) Start(_ context.Context) {
+	//No need to start json formatter
 }

--- a/pkg/format/netflow/wrapper.go
+++ b/pkg/format/netflow/wrapper.go
@@ -17,7 +17,7 @@ func NewWrapper(c chan map[string]interface{}) *TransportWrapper {
 	return &tw
 }
 
-func (w *TransportWrapper) Send(key, data []byte) error {
+func (w *TransportWrapper) Send(_, data []byte) error {
 	message := goflowpb.FlowMessage{}
 	err := proto.Unmarshal(data, &message)
 	if err != nil {

--- a/pkg/format/pb/pb.go
+++ b/pkg/format/pb/pb.go
@@ -3,6 +3,7 @@ package pb
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -79,4 +80,8 @@ func renderMac(macValue uint64) string {
 
 func (pbFormat *Format) Shutdown() {
 	//Can't shutdown pb formatter
+}
+
+func (pbFormat *Format) Start(_ context.Context) {
+	//Don't need to start json formatter
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,0 +1,126 @@
+// Package service groups the flow listening and enrichement functionalities into a single
+// service
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/netobserv/goflow2-kube-enricher/pkg/config"
+	"github.com/netobserv/goflow2-kube-enricher/pkg/export"
+	"github.com/netobserv/goflow2-kube-enricher/pkg/format"
+	jsonFormat "github.com/netobserv/goflow2-kube-enricher/pkg/format/json"
+	nfFormat "github.com/netobserv/goflow2-kube-enricher/pkg/format/netflow"
+	pbFormat "github.com/netobserv/goflow2-kube-enricher/pkg/format/pb"
+	"github.com/netobserv/goflow2-kube-enricher/pkg/meta"
+	reader "github.com/netobserv/goflow2-kube-enricher/pkg/reader"
+)
+
+const netflowScheme = "netflow"
+const legacyScheme = "nfl"
+
+type Status int
+
+const (
+	Stopped Status = iota
+	Starting
+	Started
+)
+
+func (s Status) String() string {
+	switch s {
+	case Stopped:
+		return "Stopped"
+	case Started:
+		return "Started"
+	case Starting:
+		return "Starting"
+	default:
+		return "Unknown"
+	}
+}
+
+type FlowEnricher struct {
+	status    Status
+	informers *meta.Informers
+	reader    reader.Reader
+	loki      *export.Loki
+}
+
+func NewFlowEnricher(cfg *config.Config, clientset kubernetes.Interface) (*FlowEnricher, error) {
+	var in format.Format
+	if cfg.Listen == "" {
+		switch cfg.StdinFormat {
+		case config.JSONFlagName:
+			in = jsonFormat.NewScanner(os.Stdin)
+		case config.PBFlagName:
+			in = pbFormat.NewScanner(os.Stdin)
+		default:
+			return nil, fmt.Errorf("unknown source format: %s", cfg.StdinFormat)
+		}
+	} else {
+		listenAddrURL, err := url.Parse(cfg.Listen)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't parse the listen address URL")
+		}
+		if listenAddrURL.Scheme == netflowScheme || listenAddrURL.Scheme == legacyScheme {
+			hostname := listenAddrURL.Hostname()
+			port, err := strconv.ParseUint(listenAddrURL.Port(), 10, 64)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed reading listening port")
+			}
+			in = nfFormat.NewDriver(hostname, int(port), listenAddrURL.Scheme == legacyScheme)
+		} else {
+			return nil, fmt.Errorf("unknown listening protocol %q", listenAddrURL.Scheme)
+		}
+	}
+
+	loki, err := export.NewLoki(&cfg.Loki)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't create Loki exporter")
+	}
+
+	informers := meta.NewInformers(clientset)
+	flowReader, err := reader.NewReader(cfg, in, &informers)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't instantiate reader instance")
+	}
+	return &FlowEnricher{
+		status:    Stopped,
+		informers: &informers,
+		reader:    flowReader,
+		loki:      &loki,
+	}, nil
+}
+
+func (fe *FlowEnricher) Start(ctx context.Context) {
+	fe.status = Starting
+
+	// Starts informers to get updated information about kubernetes entities
+	log := logrus.WithField("component", "reader.Reader")
+	log.Info("starting Kubernetes informers")
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	if err := fe.informers.Start(stopCh); err != nil {
+		log.WithError(err).Fatal("can't start informers")
+	}
+	log.Info("waiting for informers to be synchronized")
+	fe.informers.WaitForCacheSync(stopCh)
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		fe.informers.DebugInfo(log.Writer())
+	}
+	// Start format-enrich loop
+	fe.status = Started
+	fe.reader.Start(ctx)
+}
+
+func (fe *FlowEnricher) Status() Status {
+	return fe.status
+}


### PR DESCRIPTION
Prior to future refactorings for optimization, the components' instantiation + initialization + main loop have been separated.

Also, the loki emitter has been removed from the "enrich" process and moved to the same level, in the read/enrich/submit loop.

Also, the whole service build is moved to a common package, so we can make sure that the main function and the integration tests use the same service structure.